### PR TITLE
/etc/hostname must not contain comments on anxient OSes

### DIFF
--- a/internal/netconf/hostname.tpl
+++ b/internal/netconf/hostname.tpl
@@ -1,3 +1,2 @@
 {{- /*gotype: github.com/metal-stack/metal-networker/internal/netconf.HostnameData*/ -}}
-{{ .Comment }}
 {{ .Hostname }}

--- a/internal/netconf/testdata/hostname
+++ b/internal/netconf/testdata/hostname
@@ -1,3 +1,1 @@
-# This file was auto generated for machine: 'e0ab02d2-27cd-5a5e-8efc-080ba80cf258' by app version .
-# Do not edit.
 firewall


### PR DESCRIPTION
closes #13 