### PR TITLE
Adapt to new firewall-controller

### DIFF
--- a/internal/netconf/firewall_controller.go
+++ b/internal/netconf/firewall_controller.go
@@ -30,13 +30,9 @@ func NewFirewallControllerServiceApplier(kb KnowledgeBase, v net.Validator) (net
 	if len(kb.getPrivatePrimaryNetwork().Ips) == 0 {
 		return nil, fmt.Errorf("no private IP found useable for the firewall controller")
 	}
-	serviceIP := kb.getPrivatePrimaryNetwork().Ips[0]
-	privateVrfID := kb.getPrivatePrimaryNetwork().Vrf
 	data := FirewallControllerData{
 		Comment:         versionHeader(kb.Machineuuid),
 		DefaultRouteVrf: defaultRouteVrf,
-		ServiceIP:       serviceIP,
-		PrivateVrfID:    *privateVrfID,
 	}
 
 	return net.NewNetworkApplier(data, v, nil), nil

--- a/internal/netconf/testdata/firewall-controller.service
+++ b/internal/netconf/testdata/firewall-controller.service
@@ -7,7 +7,7 @@ After=network.target
 [Service]
 LimitMEMLOCK=infinity
 Environment=KUBECONFIG=/etc/firewall-controller/.kubeconfig
-ExecStart=/bin/ip vrf exec vrf104009 /usr/local/bin/firewall-controller --service-ip 10.0.16.2 --private-vrf 3981
+ExecStart=/bin/ip vrf exec vrf104009 /usr/local/bin/firewall-controller
 Restart=always
 RestartSec=10
 

--- a/internal/netconf/tpl/firewall_controller.service.tpl
+++ b/internal/netconf/tpl/firewall_controller.service.tpl
@@ -7,7 +7,7 @@ After=network.target
 [Service]
 LimitMEMLOCK=infinity
 Environment=KUBECONFIG=/etc/firewall-controller/.kubeconfig
-ExecStart=/bin/ip vrf exec {{ .DefaultRouteVrf }} /usr/local/bin/firewall-controller --service-ip {{ .ServiceIP }} --private-vrf {{ .PrivateVrfID }}
+ExecStart=/bin/ip vrf exec {{ .DefaultRouteVrf }} /usr/local/bin/firewall-controller
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
ServiceIP and Private VRF ID does not need to be passed anymore to the firewall-controller with CLI Flags because this information is accessible from the firewall object which contains the machine networks.