### PR TITLE
add MTUBytes=9000 to bridge netdev

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -278,6 +278,7 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=

--- a/internal/netconf/testdata/networkd/firewall/20-bridge.netdev
+++ b/internal/netconf/testdata/networkd/firewall/20-bridge.netdev
@@ -3,6 +3,7 @@
 [NetDev]
 Name=bridge
 Kind=bridge
+MTUBytes=9000
 
 [Bridge]
 DefaultPVID=none

--- a/internal/netconf/tpl/networkd/20-bridge.netdev.tpl
+++ b/internal/netconf/tpl/networkd/20-bridge.netdev.tpl
@@ -3,6 +3,7 @@
 [NetDev]
 Name=bridge
 Kind=bridge
+MTUBytes=9000
 
 [Bridge]
 DefaultPVID=none


### PR DESCRIPTION
on debian based firewalls, the bridge network has MTU of 1500 while the MTU of the virtual interfaces is 9000:

```
11: vlan64@bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master vrf64 state UP mode DEFAULT group default qlen 1000
12: vlan104009@bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master vrf104009 state UP mode DEFAULT group default qlen 1000
13: vni64: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue master bridge state UNKNOWN mode DEFAULT group default qlen 1000
14: vni104009: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue master bridge state UNKNOWN mode DEFAULT group default qlen 1000
```

With MTUBytes=9000  in /etc/systemd/network/20-bridge.netdev the bridge interface has also 9000:

```
11: vlan64@bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue master vrf64 state UP mode DEFAULT group default qlen 1000
12: vlan104009@bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue master vrf104009 state UP mode DEFAULT group default qlen 1000
13: vni64: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue master bridge state UNKNOWN mode DEFAULT group default qlen 1000
14: vni104009: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue master bridge state UNKNOWN mode DEFAULT group default qlen 1000
```