### PR TITLE
disable ids logs by default

### DIFF
--- a/pkg/netconf/suricata_config.go
+++ b/pkg/netconf/suricata_config.go
@@ -14,6 +14,7 @@ type SuricataConfigData struct {
 	Comment         string
 	DefaultRouteVrf string
 	Interface       string
+	EnableIDS       bool
 }
 
 // SuricataConfigValidator can validate configuration for suricata.
@@ -22,14 +23,19 @@ type SuricataConfigValidator struct {
 }
 
 // NewSuricataConfigApplier constructs a new instance of this type.
-func NewSuricataConfigApplier(kb KnowledgeBase, tmpFile string) (net.Applier, error) {
+func NewSuricataConfigApplier(kb KnowledgeBase, tmpFile string, enableIDS bool) (net.Applier, error) {
 	defaultRouteVrf, err := kb.getDefaultRouteVRFName()
 	if err != nil {
 		return nil, err
 	}
 
 	i := strings.Replace(defaultRouteVrf, "vrf", "vlan", 1)
-	data := SuricataConfigData{Comment: versionHeader(kb.Machineuuid), DefaultRouteVrf: defaultRouteVrf, Interface: i}
+	data := SuricataConfigData{
+		Comment:         versionHeader(kb.Machineuuid),
+		DefaultRouteVrf: defaultRouteVrf,
+		Interface:       i,
+		EnableIDS:       enableIDS,
+	}
 	validator := SuricataConfigValidator{tmpFile}
 
 	return net.NewNetworkApplier(data, validator, nil), nil

--- a/pkg/netconf/tpl/suricata_config.yaml.tpl
+++ b/pkg/netconf/tpl/suricata_config.yaml.tpl
@@ -81,6 +81,7 @@ outputs:
 
   # Extensible Event Format (nicknamed EVE) event log in JSON format
   - eve-log:
+      {{- if .EnableIDS }}
       enabled: yes
       filetype: regular
       filename: eve.json
@@ -287,6 +288,9 @@ outputs:
         # and will include the pktvars, flowvars, flowbits and
         # flowints.
         #- metadata
+      {{- else }}
+      enabled: no
+      {{- end }}
 
   # deprecated - unified2 alert format for use with Barnyard2
   - unified2-alert:


### PR DESCRIPTION
Now it's possible to enable/disable IDS logs in suricata. By default logs are disabled.