### PR TITLE
Raise keepalive and hold timers to be more robust

### DIFF
--- a/pkg/netconf/testdata/frr.conf.firewall
+++ b/pkg/netconf/testdata/frr.conf.firewall
@@ -42,7 +42,7 @@ router bgp 4200003073
  bgp bestpath as-path multipath-relax
  neighbor FABRIC peer-group
  neighbor FABRIC remote-as external
- neighbor FABRIC timers 1 3
+ neighbor FABRIC timers 2 8
  neighbor lan0 interface peer-group FABRIC
  neighbor lan1 interface peer-group FABRIC
  !

--- a/pkg/netconf/testdata/frr.conf.firewall_dmz
+++ b/pkg/netconf/testdata/frr.conf.firewall_dmz
@@ -38,7 +38,7 @@ router bgp 4200003073
  bgp bestpath as-path multipath-relax
  neighbor FABRIC peer-group
  neighbor FABRIC remote-as external
- neighbor FABRIC timers 1 3
+ neighbor FABRIC timers 2 8
  neighbor lan0 interface peer-group FABRIC
  neighbor lan1 interface peer-group FABRIC
  !

--- a/pkg/netconf/testdata/frr.conf.firewall_dmz_app
+++ b/pkg/netconf/testdata/frr.conf.firewall_dmz_app
@@ -34,7 +34,7 @@ router bgp 4200003073
  bgp bestpath as-path multipath-relax
  neighbor FABRIC peer-group
  neighbor FABRIC remote-as external
- neighbor FABRIC timers 1 3
+ neighbor FABRIC timers 2 8
  neighbor lan0 interface peer-group FABRIC
  neighbor lan1 interface peer-group FABRIC
  !

--- a/pkg/netconf/testdata/frr.conf.firewall_dmz_app_storage
+++ b/pkg/netconf/testdata/frr.conf.firewall_dmz_app_storage
@@ -38,7 +38,7 @@ router bgp 4200003073
  bgp bestpath as-path multipath-relax
  neighbor FABRIC peer-group
  neighbor FABRIC remote-as external
- neighbor FABRIC timers 1 3
+ neighbor FABRIC timers 2 8
  neighbor lan0 interface peer-group FABRIC
  neighbor lan1 interface peer-group FABRIC
  !

--- a/pkg/netconf/testdata/frr.conf.firewall_ipv6
+++ b/pkg/netconf/testdata/frr.conf.firewall_ipv6
@@ -42,7 +42,7 @@ router bgp 4200003073
  bgp bestpath as-path multipath-relax
  neighbor FABRIC peer-group
  neighbor FABRIC remote-as external
- neighbor FABRIC timers 1 3
+ neighbor FABRIC timers 2 8
  neighbor lan0 interface peer-group FABRIC
  neighbor lan1 interface peer-group FABRIC
  !

--- a/pkg/netconf/testdata/frr.conf.firewall_shared
+++ b/pkg/netconf/testdata/frr.conf.firewall_shared
@@ -34,7 +34,7 @@ router bgp 4200003073
  bgp bestpath as-path multipath-relax
  neighbor FABRIC peer-group
  neighbor FABRIC remote-as external
- neighbor FABRIC timers 1 3
+ neighbor FABRIC timers 2 8
  neighbor lan0 interface peer-group FABRIC
  neighbor lan1 interface peer-group FABRIC
  !

--- a/pkg/netconf/testdata/frr.conf.machine
+++ b/pkg/netconf/testdata/frr.conf.machine
@@ -28,12 +28,12 @@ router bgp 4200003073
  bgp bestpath as-path multipath-relax
  neighbor TOR peer-group
  neighbor TOR remote-as external
- neighbor TOR timers 1 3
+ neighbor TOR timers 2 8
  neighbor lan0 interface peer-group TOR
  neighbor lan1 interface peer-group TOR
  neighbor LOCAL peer-group
  neighbor LOCAL remote-as internal
- neighbor LOCAL timers 1 3
+ neighbor LOCAL timers 2 8
  neighbor LOCAL route-map local-in in
  bgp listen range 10.244.0.0/16 peer-group LOCAL
  !

--- a/pkg/netconf/tpl/frr.firewall.tpl
+++ b/pkg/netconf/tpl/frr.firewall.tpl
@@ -34,7 +34,7 @@ router bgp {{ .ASN }}
  bgp bestpath as-path multipath-relax
  neighbor FABRIC peer-group
  neighbor FABRIC remote-as external
- neighbor FABRIC timers 1 3
+ neighbor FABRIC timers 2 8
  neighbor lan0 interface peer-group FABRIC
  neighbor lan1 interface peer-group FABRIC
  !

--- a/pkg/netconf/tpl/frr.machine.tpl
+++ b/pkg/netconf/tpl/frr.machine.tpl
@@ -30,12 +30,12 @@ router bgp {{ .ASN }}
  bgp bestpath as-path multipath-relax
  neighbor TOR peer-group
  neighbor TOR remote-as external
- neighbor TOR timers 1 3
+ neighbor TOR timers 2 8
  neighbor lan0 interface peer-group TOR
  neighbor lan1 interface peer-group TOR
  neighbor LOCAL peer-group
  neighbor LOCAL remote-as internal
- neighbor LOCAL timers 1 3
+ neighbor LOCAL timers 2 8
  neighbor LOCAL route-map local-in in
  bgp listen range 10.244.0.0/16 peer-group LOCAL
  !


### PR DESCRIPTION
Sometimes the switches are not able to answer bgp hold within specified hold time of 3s which then leads to a bgp session termination on the affected interface and this will lead to ECMP rehashing and this will lead to connection resets in certain conditions.

With this two things changed:
1. keepalive timer is raised from 1s to 2s which reduces the amount of work the switch has to maintain to send bgp keepalives.
2. bgp hold time is raised from 3s to 8s to survive some latencies from slow switch control plane.