### PR TITLE
add envvar to disable logging to log.tailscale.io

### DIFF
--- a/pkg/netconf/tpl/tailscaled.service.tpl
+++ b/pkg/netconf/tpl/tailscaled.service.tpl
@@ -9,6 +9,7 @@ LimitMEMLOCK=infinity
 User=root
 Group=root
 Type=notify
+Environment="TS_NO_LOGS_NO_SUPPORT=true"
 ExecStartPre=ip vrf exec {{ .DefaultRouteVrf }} /usr/local/bin/tailscaled --cleanup
 ExecStart=/bin/ip vrf exec {{ .DefaultRouteVrf }} /usr/local/bin/tailscaled --port {{ .TailscaledPort }}
 ExecStopPost=ip vrf exec {{ .DefaultRouteVrf }} /usr/local/bin/tailscaled --cleanup


### PR DESCRIPTION
Solves https://github.com/metal-stack/metal-networker/issues/88 by setting environment variable `TS_NO_LOGS_NO_SUPPORT` in systemd service file.