### PR TITLE
fix tailscaled service

### DIFF
--- a/pkg/netconf/tpl/tailscaled.service.tpl
+++ b/pkg/netconf/tpl/tailscaled.service.tpl
@@ -1,8 +1,7 @@
 [Unit]
 Description=Tailscale node agent
 Documentation=https://tailscale.com/kb/
-Wants=network-pre.target
-After=network-pre.target network.target systemd-resolved.service
+After=network.target
 
 [Service]
 LimitMEMLOCK=infinity


### PR DESCRIPTION
https://serverfault.com/a/812589/505922 makes an assumption(it's not 100% clear if it's true), that:

> After= is a "loose coupling", and a service with such a statement would still run if the one named in the After= line isn't started at all

`network-pre` target was included in `After`, which starts before interfaces are configured, so if above statement is correct that would cause a problem with VRF. Therefore only `network` target is left in `After` section(`firewall-controller` service does the same).