### PR TITLE
Firewall Precedence

### DIFF
--- a/pkg/netconf/frr.go
+++ b/pkg/netconf/frr.go
@@ -143,7 +143,7 @@ func assembleVRFs(kb config) []VRF {
 			VNI:            int(*network.Vrf),
 			ImportVRFNames: i.ImportVRFs,
 			IPPrefixLists:  i.prefixLists(),
-			RouteMaps:      i.routeMaps(),
+			RouteMaps:      i.routeMaps(*network.Asn),
 		}
 		result = append(result, vrf)
 	}

--- a/pkg/netconf/routemap.go
+++ b/pkg/netconf/routemap.go
@@ -282,7 +282,7 @@ func byName(prefixLists []IPPrefixList) map[string]IPPrefixList {
 	return byName
 }
 
-func (i *importRule) routeMaps() []RouteMap {
+func (i *importRule) routeMaps(asn int64) []RouteMap {
 	var result []RouteMap
 
 	order := RouteMapOrderSeed
@@ -299,7 +299,8 @@ func (i *importRule) routeMaps() []RouteMap {
 
 		matchVrf := fmt.Sprintf("match source-vrf %s", prefixList.SourceVRF)
 		matchPfxList := fmt.Sprintf("match %s address prefix-list %s", prefixList.AddressFamily, n)
-		entries := []string{matchVrf, matchPfxList}
+		asPathPrepend := fmt.Sprintf("set as-path prepend %d %d", asn, asn)
+		entries := []string{matchVrf, matchPfxList, asPathPrepend}
 		if strings.HasSuffix(n, IPPrefixListNoExportSuffix) {
 			entries = append(entries, "set community additive no-export")
 		}

--- a/pkg/netconf/testdata/frr.conf.firewall
+++ b/pkg/netconf/testdata/frr.conf.firewall
@@ -160,12 +160,15 @@ ip prefix-list vrf3981-import-from-vrf3982 seq 106 permit 10.0.18.0/22 le 32
 route-map vrf3981-import-map permit 10
  match source-vrf vrf3982
  match ip address prefix-list vrf3981-import-from-vrf3982
+ set as-path prepend 4200003073 4200003073
 route-map vrf3981-import-map permit 20
  match source-vrf vrf104010
  match ip address prefix-list vrf3981-import-from-vrf104010
+ set as-path prepend 4200003073 4200003073
 route-map vrf3981-import-map permit 30
  match source-vrf vrf104009
  match ip address prefix-list vrf3981-import-from-vrf104009
+ set as-path prepend 4200003073 4200003073
 route-map vrf3981-import-map deny 40
 !
 ip prefix-list vrf3982-import-from-vrf3981 seq 100 permit 10.0.16.0/22 le 32
@@ -173,6 +176,7 @@ ip prefix-list vrf3982-import-from-vrf3981 seq 101 permit 10.0.18.0/22 le 32
 route-map vrf3982-import-map permit 10
  match source-vrf vrf3981
  match ip address prefix-list vrf3982-import-from-vrf3981
+ set as-path prepend 4200003073 4200003073
 route-map vrf3982-import-map deny 20
 !
 ip prefix-list vrf104009-import-from-vrf3981-no-export seq 100 permit 10.0.16.0/22 le 32
@@ -181,10 +185,12 @@ ip prefix-list vrf104009-import-from-vrf3981 seq 102 permit 185.27.0.0/22 le 32
 route-map vrf104009-import-map permit 10
  match source-vrf vrf3981
  match ip address prefix-list vrf104009-import-from-vrf3981-no-export
+ set as-path prepend 4200003073 4200003073
  set community additive no-export
 route-map vrf104009-import-map permit 20
  match source-vrf vrf3981
  match ip address prefix-list vrf104009-import-from-vrf3981
+ set as-path prepend 4200003073 4200003073
 route-map vrf104009-import-map deny 30
 !
 ip prefix-list vrf104010-import-from-vrf3981-no-export seq 100 permit 10.0.16.0/22 le 32
@@ -192,10 +198,12 @@ ip prefix-list vrf104010-import-from-vrf3981 seq 101 permit 100.127.129.0/24 le 
 route-map vrf104010-import-map permit 10
  match source-vrf vrf3981
  match ip address prefix-list vrf104010-import-from-vrf3981-no-export
+ set as-path prepend 4200003073 4200003073
  set community additive no-export
 route-map vrf104010-import-map permit 20
  match source-vrf vrf3981
  match ip address prefix-list vrf104010-import-from-vrf3981
+ set as-path prepend 4200003073 4200003073
 route-map vrf104010-import-map deny 30
 !
 route-map only-self-out permit 10


### PR DESCRIPTION
Closes #97 

Idea: Prolong AS-Path in all directions (except the underlay)
- for IPs of external networks produced in a cluster
- for routes to storage
- for the default routes / internet access of the cluster