### PR TITLE
Rename set public_dns_servers to proxy_dns_servers

### DIFF
--- a/pkg/netconf/nftables.go
+++ b/pkg/netconf/nftables.go
@@ -190,7 +190,7 @@ func getDNSProxyDNAT(c config, port, zone string) DNAT {
 	return DNAT{
 		Comment:      "dnat to dns proxy",
 		InInterfaces: svis,
-		DAddr:        "@public_dns_servers",
+		DAddr:        "@proxy_dns_servers",
 		Port:         port,
 		Zone:         zone,
 		DestSpec: AddrSpec{

--- a/pkg/netconf/testdata/nftrules
+++ b/pkg/netconf/testdata/nftrules
@@ -47,7 +47,7 @@ table inet metal {
     }
 }
 table inet nat {
-    set public_dns_servers {
+    set proxy_dns_servers {
     	type ipv4_addr
     	flags interval
     	auto-merge

--- a/pkg/netconf/testdata/nftrules_accept_forwarding
+++ b/pkg/netconf/testdata/nftrules_accept_forwarding
@@ -47,7 +47,7 @@ table inet metal {
     }
 }
 table inet nat {
-    set public_dns_servers {
+    set proxy_dns_servers {
     	type ipv4_addr
     	flags interval
     	auto-merge

--- a/pkg/netconf/testdata/nftrules_dmz
+++ b/pkg/netconf/testdata/nftrules_dmz
@@ -54,7 +54,7 @@ table inet metal {
     }
 }
 table inet nat {
-    set public_dns_servers {
+    set proxy_dns_servers {
     	type ipv4_addr
     	flags interval
     	auto-merge
@@ -63,10 +63,10 @@ table inet nat {
 
     chain prerouting {
         type nat hook prerouting priority 0; policy accept;
-        ip daddr @public_dns_servers iifname "vlan3981" tcp dport domain dnat ip to 185.1.2.3 comment "dnat to dns proxy"
-        ip daddr @public_dns_servers iifname "vlan3981" udp dport domain dnat ip to 185.1.2.3 comment "dnat to dns proxy"
-        ip daddr @public_dns_servers iifname "vlan3983" tcp dport domain dnat ip to 185.1.2.3 comment "dnat to dns proxy"
-        ip daddr @public_dns_servers iifname "vlan3983" udp dport domain dnat ip to 185.1.2.3 comment "dnat to dns proxy"
+        ip daddr @proxy_dns_servers iifname "vlan3981" tcp dport domain dnat ip to 185.1.2.3 comment "dnat to dns proxy"
+        ip daddr @proxy_dns_servers iifname "vlan3981" udp dport domain dnat ip to 185.1.2.3 comment "dnat to dns proxy"
+        ip daddr @proxy_dns_servers iifname "vlan3983" tcp dport domain dnat ip to 185.1.2.3 comment "dnat to dns proxy"
+        ip daddr @proxy_dns_servers iifname "vlan3983" udp dport domain dnat ip to 185.1.2.3 comment "dnat to dns proxy"
     }
     chain prerouting_ct {
         type filter hook prerouting priority raw; policy accept;

--- a/pkg/netconf/testdata/nftrules_dmz_app
+++ b/pkg/netconf/testdata/nftrules_dmz_app
@@ -54,7 +54,7 @@ table inet metal {
     }
 }
 table inet nat {
-    set public_dns_servers {
+    set proxy_dns_servers {
     	type ipv4_addr
     	flags interval
     	auto-merge
@@ -63,10 +63,10 @@ table inet nat {
 
     chain prerouting {
         type nat hook prerouting priority 0; policy accept;
-        ip daddr @public_dns_servers iifname "vlan3981" tcp dport domain dnat ip to 10.0.20.2 comment "dnat to dns proxy"
-        ip daddr @public_dns_servers iifname "vlan3981" udp dport domain dnat ip to 10.0.20.2 comment "dnat to dns proxy"
-        ip daddr @public_dns_servers iifname "vlan3983" tcp dport domain dnat ip to 10.0.20.2 comment "dnat to dns proxy"
-        ip daddr @public_dns_servers iifname "vlan3983" udp dport domain dnat ip to 10.0.20.2 comment "dnat to dns proxy"
+        ip daddr @proxy_dns_servers iifname "vlan3981" tcp dport domain dnat ip to 10.0.20.2 comment "dnat to dns proxy"
+        ip daddr @proxy_dns_servers iifname "vlan3981" udp dport domain dnat ip to 10.0.20.2 comment "dnat to dns proxy"
+        ip daddr @proxy_dns_servers iifname "vlan3983" tcp dport domain dnat ip to 10.0.20.2 comment "dnat to dns proxy"
+        ip daddr @proxy_dns_servers iifname "vlan3983" udp dport domain dnat ip to 10.0.20.2 comment "dnat to dns proxy"
     }
     chain prerouting_ct {
         type filter hook prerouting priority raw; policy accept;

--- a/pkg/netconf/testdata/nftrules_ipv6
+++ b/pkg/netconf/testdata/nftrules_ipv6
@@ -54,7 +54,7 @@ table inet metal {
     }
 }
 table inet nat {
-    set public_dns_servers {
+    set proxy_dns_servers {
     	type ipv4_addr
     	flags interval
     	auto-merge
@@ -63,10 +63,10 @@ table inet nat {
 
     chain prerouting {
         type nat hook prerouting priority 0; policy accept;
-        ip6 daddr @public_dns_servers iifname "vlan3981" tcp dport domain dnat ip6 to 2a02:c00:20::1 comment "dnat to dns proxy"
-        ip6 daddr @public_dns_servers iifname "vlan3981" udp dport domain dnat ip6 to 2a02:c00:20::1 comment "dnat to dns proxy"
-        ip6 daddr @public_dns_servers iifname "vlan3982" tcp dport domain dnat ip6 to 2a02:c00:20::1 comment "dnat to dns proxy"
-        ip6 daddr @public_dns_servers iifname "vlan3982" udp dport domain dnat ip6 to 2a02:c00:20::1 comment "dnat to dns proxy"
+        ip6 daddr @proxy_dns_servers iifname "vlan3981" tcp dport domain dnat ip6 to 2a02:c00:20::1 comment "dnat to dns proxy"
+        ip6 daddr @proxy_dns_servers iifname "vlan3981" udp dport domain dnat ip6 to 2a02:c00:20::1 comment "dnat to dns proxy"
+        ip6 daddr @proxy_dns_servers iifname "vlan3982" tcp dport domain dnat ip6 to 2a02:c00:20::1 comment "dnat to dns proxy"
+        ip6 daddr @proxy_dns_servers iifname "vlan3982" udp dport domain dnat ip6 to 2a02:c00:20::1 comment "dnat to dns proxy"
     }
     chain prerouting_ct {
         type filter hook prerouting priority raw; policy accept;

--- a/pkg/netconf/testdata/nftrules_shared
+++ b/pkg/netconf/testdata/nftrules_shared
@@ -52,7 +52,7 @@ table inet metal {
     }
 }
 table inet nat {
-    set public_dns_servers {
+    set proxy_dns_servers {
     	type ipv4_addr
     	flags interval
     	auto-merge
@@ -61,8 +61,8 @@ table inet nat {
 
     chain prerouting {
         type nat hook prerouting priority 0; policy accept;
-        ip daddr @public_dns_servers iifname "vlan3982" tcp dport domain dnat ip to 185.1.2.3 comment "dnat to dns proxy"
-        ip daddr @public_dns_servers iifname "vlan3982" udp dport domain dnat ip to 185.1.2.3 comment "dnat to dns proxy"
+        ip daddr @proxy_dns_servers iifname "vlan3982" tcp dport domain dnat ip to 185.1.2.3 comment "dnat to dns proxy"
+        ip daddr @proxy_dns_servers iifname "vlan3982" udp dport domain dnat ip to 185.1.2.3 comment "dnat to dns proxy"
     }
     chain prerouting_ct {
         type filter hook prerouting priority raw; policy accept;

--- a/pkg/netconf/testdata/nftrules_vpn
+++ b/pkg/netconf/testdata/nftrules_vpn
@@ -47,7 +47,7 @@ table inet metal {
     }
 }
 table inet nat {
-    set public_dns_servers {
+    set proxy_dns_servers {
     	type ipv4_addr
     	flags interval
     	auto-merge

--- a/pkg/netconf/testdata/nftrules_with_rules
+++ b/pkg/netconf/testdata/nftrules_with_rules
@@ -56,7 +56,7 @@ table inet metal {
     }
 }
 table inet nat {
-    set public_dns_servers {
+    set proxy_dns_servers {
     	type ipv4_addr
     	flags interval
     	auto-merge

--- a/pkg/netconf/tpl/nftrules.tpl
+++ b/pkg/netconf/tpl/nftrules.tpl
@@ -70,7 +70,7 @@ table inet metal {
     }
 }
 table inet nat {
-    set public_dns_servers {
+    set proxy_dns_servers {
     	type ipv4_addr
     	flags interval
     	auto-merge


### PR DESCRIPTION
Renaming suggested in https://github.com/metal-stack/firewall-controller/pull/177#discussion_r1568932876

DNS Servers don't have to be public anymore.