### PR TITLE
Activate allow-reserved-ranges for peering via 127.0.0.0/8

### DIFF
--- a/pkg/netconf/frr.go
+++ b/pkg/netconf/frr.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// FRRVersion holds a string that is used in the frr.conf to define the FRR version.
-	FRRVersion = "8.3"
+	FRRVersion = "8.5"
 	// TplFirewallFRR defines the name of the template to render FRR configuration to a 'firewall'.
 	TplFirewallFRR = "frr.firewall.tpl"
 	// TplMachineFRR defines the name of the template to render FRR configuration to a 'machine'.

--- a/pkg/netconf/testdata/frr.conf.firewall
+++ b/pkg/netconf/testdata/frr.conf.firewall
@@ -5,8 +5,6 @@ frr defaults datacenter
 hostname firewall
 username cumulus nopassword
 !
-service integrated-vtysh-config
-!
 log syslog debugging
 debug bgp updates
 debug bgp nht

--- a/pkg/netconf/testdata/frr.conf.firewall
+++ b/pkg/netconf/testdata/frr.conf.firewall
@@ -1,6 +1,6 @@
 # This file was auto generated for machine: 'e0ab02d2-27cd-5a5e-8efc-080ba80cf258' by app version .
 # Do not edit.
-frr version 8.3
+frr version 8.5
 frr defaults datacenter
 hostname firewall
 username cumulus nopassword

--- a/pkg/netconf/testdata/frr.conf.firewall
+++ b/pkg/netconf/testdata/frr.conf.firewall
@@ -3,7 +3,6 @@
 frr version 8.5
 frr defaults datacenter
 hostname firewall
-username cumulus nopassword
 !
 log syslog debugging
 debug bgp updates

--- a/pkg/netconf/testdata/frr.conf.firewall_dmz
+++ b/pkg/netconf/testdata/frr.conf.firewall_dmz
@@ -5,8 +5,6 @@ frr defaults datacenter
 hostname firewall
 username cumulus nopassword
 !
-service integrated-vtysh-config
-!
 log syslog debugging
 debug bgp updates
 debug bgp nht

--- a/pkg/netconf/testdata/frr.conf.firewall_dmz
+++ b/pkg/netconf/testdata/frr.conf.firewall_dmz
@@ -1,6 +1,6 @@
 # This file was auto generated for machine: 'e0ab02d2-27cd-5a5e-8efc-080ba80cf258' by app version .
 # Do not edit.
-frr version 8.3
+frr version 8.5
 frr defaults datacenter
 hostname firewall
 username cumulus nopassword

--- a/pkg/netconf/testdata/frr.conf.firewall_dmz
+++ b/pkg/netconf/testdata/frr.conf.firewall_dmz
@@ -3,7 +3,6 @@
 frr version 8.5
 frr defaults datacenter
 hostname firewall
-username cumulus nopassword
 !
 log syslog debugging
 debug bgp updates

--- a/pkg/netconf/testdata/frr.conf.firewall_dmz_app
+++ b/pkg/netconf/testdata/frr.conf.firewall_dmz_app
@@ -5,8 +5,6 @@ frr defaults datacenter
 hostname firewall
 username cumulus nopassword
 !
-service integrated-vtysh-config
-!
 log syslog debugging
 debug bgp updates
 debug bgp nht

--- a/pkg/netconf/testdata/frr.conf.firewall_dmz_app
+++ b/pkg/netconf/testdata/frr.conf.firewall_dmz_app
@@ -1,6 +1,6 @@
 # This file was auto generated for machine: 'e0ab02d2-27cd-5a5e-8efc-080ba80cf258' by app version .
 # Do not edit.
-frr version 8.3
+frr version 8.5
 frr defaults datacenter
 hostname firewall
 username cumulus nopassword

--- a/pkg/netconf/testdata/frr.conf.firewall_dmz_app
+++ b/pkg/netconf/testdata/frr.conf.firewall_dmz_app
@@ -3,7 +3,6 @@
 frr version 8.5
 frr defaults datacenter
 hostname firewall
-username cumulus nopassword
 !
 log syslog debugging
 debug bgp updates

--- a/pkg/netconf/testdata/frr.conf.firewall_dmz_app_storage
+++ b/pkg/netconf/testdata/frr.conf.firewall_dmz_app_storage
@@ -5,8 +5,6 @@ frr defaults datacenter
 hostname firewall
 username cumulus nopassword
 !
-service integrated-vtysh-config
-!
 log syslog debugging
 debug bgp updates
 debug bgp nht

--- a/pkg/netconf/testdata/frr.conf.firewall_dmz_app_storage
+++ b/pkg/netconf/testdata/frr.conf.firewall_dmz_app_storage
@@ -1,6 +1,6 @@
 # This file was auto generated for machine: 'e0ab02d2-27cd-5a5e-8efc-080ba80cf258' by app version .
 # Do not edit.
-frr version 8.3
+frr version 8.5
 frr defaults datacenter
 hostname firewall
 username cumulus nopassword

--- a/pkg/netconf/testdata/frr.conf.firewall_dmz_app_storage
+++ b/pkg/netconf/testdata/frr.conf.firewall_dmz_app_storage
@@ -3,7 +3,6 @@
 frr version 8.5
 frr defaults datacenter
 hostname firewall
-username cumulus nopassword
 !
 log syslog debugging
 debug bgp updates

--- a/pkg/netconf/testdata/frr.conf.firewall_ipv6
+++ b/pkg/netconf/testdata/frr.conf.firewall_ipv6
@@ -5,8 +5,6 @@ frr defaults datacenter
 hostname firewall
 username cumulus nopassword
 !
-service integrated-vtysh-config
-!
 log syslog debugging
 debug bgp updates
 debug bgp nht

--- a/pkg/netconf/testdata/frr.conf.firewall_ipv6
+++ b/pkg/netconf/testdata/frr.conf.firewall_ipv6
@@ -1,6 +1,6 @@
 # This file was auto generated for machine: 'e0ab02d2-27cd-5a5e-8efc-080ba80cf258' by app version .
 # Do not edit.
-frr version 8.3
+frr version 8.5
 frr defaults datacenter
 hostname firewall
 username cumulus nopassword

--- a/pkg/netconf/testdata/frr.conf.firewall_ipv6
+++ b/pkg/netconf/testdata/frr.conf.firewall_ipv6
@@ -3,7 +3,6 @@
 frr version 8.5
 frr defaults datacenter
 hostname firewall
-username cumulus nopassword
 !
 log syslog debugging
 debug bgp updates

--- a/pkg/netconf/testdata/frr.conf.firewall_shared
+++ b/pkg/netconf/testdata/frr.conf.firewall_shared
@@ -5,8 +5,6 @@ frr defaults datacenter
 hostname firewall
 username cumulus nopassword
 !
-service integrated-vtysh-config
-!
 log syslog debugging
 debug bgp updates
 debug bgp nht

--- a/pkg/netconf/testdata/frr.conf.firewall_shared
+++ b/pkg/netconf/testdata/frr.conf.firewall_shared
@@ -1,6 +1,6 @@
 # This file was auto generated for machine: 'e0ab02d2-27cd-5a5e-8efc-080ba80cf258' by app version .
 # Do not edit.
-frr version 8.3
+frr version 8.5
 frr defaults datacenter
 hostname firewall
 username cumulus nopassword

--- a/pkg/netconf/testdata/frr.conf.firewall_shared
+++ b/pkg/netconf/testdata/frr.conf.firewall_shared
@@ -3,7 +3,6 @@
 frr version 8.5
 frr defaults datacenter
 hostname firewall
-username cumulus nopassword
 !
 log syslog debugging
 debug bgp updates

--- a/pkg/netconf/testdata/frr.conf.machine
+++ b/pkg/netconf/testdata/frr.conf.machine
@@ -4,6 +4,7 @@ frr version 8.5
 frr defaults datacenter
 hostname machine
 username cumulus nopassword
+allow-reserved-ranges
 !
 service integrated-vtysh-config
 !

--- a/pkg/netconf/testdata/frr.conf.machine
+++ b/pkg/netconf/testdata/frr.conf.machine
@@ -6,8 +6,6 @@ hostname machine
 username cumulus nopassword
 allow-reserved-ranges
 !
-service integrated-vtysh-config
-!
 log syslog debugging
 debug bgp updates
 debug bgp nht

--- a/pkg/netconf/testdata/frr.conf.machine
+++ b/pkg/netconf/testdata/frr.conf.machine
@@ -3,7 +3,6 @@
 frr version 8.5
 frr defaults datacenter
 hostname machine
-username cumulus nopassword
 allow-reserved-ranges
 !
 log syslog debugging

--- a/pkg/netconf/testdata/frr.conf.machine
+++ b/pkg/netconf/testdata/frr.conf.machine
@@ -1,6 +1,6 @@
 # This file was auto generated for machine: 'e0ab02d2-27cd-5a5e-8efc-080ba80cf258' by app version .
 # Do not edit.
-frr version 8.3
+frr version 8.5
 frr defaults datacenter
 hostname machine
 username cumulus nopassword

--- a/pkg/netconf/tpl/frr.firewall.tpl
+++ b/pkg/netconf/tpl/frr.firewall.tpl
@@ -5,7 +5,6 @@
 frr version {{ .FRRVersion }}
 frr defaults datacenter
 hostname {{ .Hostname }}
-username cumulus nopassword
 !
 log syslog debugging
 debug bgp updates

--- a/pkg/netconf/tpl/frr.firewall.tpl
+++ b/pkg/netconf/tpl/frr.firewall.tpl
@@ -7,8 +7,6 @@ frr defaults datacenter
 hostname {{ .Hostname }}
 username cumulus nopassword
 !
-service integrated-vtysh-config
-!
 log syslog debugging
 debug bgp updates
 debug bgp nht

--- a/pkg/netconf/tpl/frr.machine.tpl
+++ b/pkg/netconf/tpl/frr.machine.tpl
@@ -5,7 +5,6 @@
 frr version {{ .FRRVersion }}
 frr defaults datacenter
 hostname {{ .Hostname }}
-username cumulus nopassword
 allow-reserved-ranges
 !
 log syslog debugging

--- a/pkg/netconf/tpl/frr.machine.tpl
+++ b/pkg/netconf/tpl/frr.machine.tpl
@@ -8,8 +8,6 @@ hostname {{ .Hostname }}
 username cumulus nopassword
 allow-reserved-ranges
 !
-service integrated-vtysh-config
-!
 log syslog debugging
 debug bgp updates
 debug bgp nht

--- a/pkg/netconf/tpl/frr.machine.tpl
+++ b/pkg/netconf/tpl/frr.machine.tpl
@@ -6,6 +6,7 @@ frr version {{ .FRRVersion }}
 frr defaults datacenter
 hostname {{ .Hostname }}
 username cumulus nopassword
+allow-reserved-ranges
 !
 service integrated-vtysh-config
 !


### PR DESCRIPTION
https://docs.frrouting.org/en/stable-9.0/basic.html#clicmd-allow-reserved-ranges
https://docs.frrouting.org/en/stable-8.4/basic.html#clicmd-allow-reserved-ranges