### PR TITLE
Allow ipv6 firewall rules

### DIFF
--- a/pkg/netconf/testdata/firewall_with_rules.yaml
+++ b/pkg/netconf/testdata/firewall_with_rules.yaml
@@ -198,7 +198,7 @@ firewall_rules:
       to:
         - "100.1.2.3/32"
         - "100.1.2.4/32"
-      comment: "allow incomming ssh"
+      comment: "allow incoming ssh"
     - protocol: TCP
       ports: [80,443,8080]
       from:

--- a/pkg/netconf/testdata/nftrules_with_rules
+++ b/pkg/netconf/testdata/nftrules_with_rules
@@ -27,12 +27,12 @@ table inet metal {
         ct state established,related counter accept comment "stateful forward"
         tcp dport bgp ct state new counter jump refuse comment "block bgp forward to machines"
         # egress rules specified during firewall creation
-        ip saddr { 10.0.0.0/8 } ip daddr 0.0.0.0/0 tcp dport { 443 } counter accept comment "allow apt update"
-        ip saddr { 10.0.0.0/8 } ip daddr 1.2.3.4/32 tcp dport { 443 } counter accept comment "allow apt update"
-        ip saddr { 10.0.0.0/8 } ip6 daddr ::/0 tcp dport { 443 } counter accept comment "allow apt update v6"
+        iifname { "vrf3981","vrf3982" } ip daddr 0.0.0.0/0 tcp dport { 443 } counter accept comment "allow apt update"
+        iifname { "vrf3981","vrf3982" } ip daddr 1.2.3.4/32 tcp dport { 443 } counter accept comment "allow apt update"
+        iifname { "vrf3981","vrf3982" } ip6 daddr ::/0 tcp dport { 443 } counter accept comment "allow apt update v6"
         # ingress rules specified during firewall creation
-        ip daddr { 100.1.2.3/32, 100.1.2.4/32 } ip saddr 2.3.4.0/24 tcp dport { 22 } counter accept comment "allow incomming ssh"
-        ip daddr { 100.1.2.3/32, 100.1.2.4/32 } ip saddr 192.168.1.0/16 tcp dport { 22 } counter accept comment "allow incomming ssh"
+        ip daddr { 100.1.2.3/32, 100.1.2.4/32 } ip saddr 2.3.4.0/24 tcp dport { 22 } counter accept comment "allow incoming ssh"
+        ip daddr { 100.1.2.3/32, 100.1.2.4/32 } ip saddr 192.168.1.0/16 tcp dport { 22 } counter accept comment "allow incoming ssh"
         oifname { "vrf3981", "vni3981", "vlan3981" } ip saddr 1.2.3.0/24 tcp dport { 80,443,8080 } counter accept comment ""
         oifname { "vrf3981", "vni3981", "vlan3981" } ip saddr 192.168.0.0/16 tcp dport { 80,443,8080 } counter accept comment ""
         limit rate 2/minute counter log prefix "nftables-metal-dropped: "


### PR DESCRIPTION
It is actually not possible to define IPv6 firewall rules during firewall creation because the source was specified with the tenant network as "10.0.0.0/8", use the input interface as for other firewall rules already in place.