### PR TITLE
Firewall should not enforce first as for the underlay

### DIFF
--- a/pkg/netconf/frr_test.go
+++ b/pkg/netconf/frr_test.go
@@ -23,6 +23,7 @@ func TestFrrConfigApplier(t *testing.T) {
 		{
 			name:             "firewall of a shared private network",
 			input:            "testdata/firewall_shared.yaml",
+			frrVersion:       semver.MustParse("8.5"),
 			expectedOutput:   "testdata/frr.conf.firewall_shared",
 			configuratorType: Firewall,
 			tpl:              TplFirewallFRR,
@@ -30,6 +31,7 @@ func TestFrrConfigApplier(t *testing.T) {
 		{
 			name:             "standard firewall with private primary unshared network, private secondary shared network, internet and mpls",
 			input:            "testdata/firewall.yaml",
+			frrVersion:       semver.MustParse("8.5"),
 			expectedOutput:   "testdata/frr.conf.firewall",
 			configuratorType: Firewall,
 			tpl:              TplFirewallFRR,
@@ -37,6 +39,7 @@ func TestFrrConfigApplier(t *testing.T) {
 		{
 			name:             "dmz firewall with private primary unshared network, private secondary shared dmz network, internet and mpls",
 			input:            "testdata/firewall_dmz.yaml",
+			frrVersion:       semver.MustParse("8.5"),
 			expectedOutput:   "testdata/frr.conf.firewall_dmz",
 			configuratorType: Firewall,
 			tpl:              TplFirewallFRR,
@@ -44,6 +47,7 @@ func TestFrrConfigApplier(t *testing.T) {
 		{
 			name:             "dmz firewall with private primary unshared network, private secondary shared dmz network",
 			input:            "testdata/firewall_dmz_app.yaml",
+			frrVersion:       semver.MustParse("8.5"),
 			expectedOutput:   "testdata/frr.conf.firewall_dmz_app",
 			configuratorType: Firewall,
 			tpl:              TplFirewallFRR,
@@ -51,6 +55,7 @@ func TestFrrConfigApplier(t *testing.T) {
 		{
 			name:             "firewall with private primary unshared network, private secondary shared dmz network and private secondary shared storage network",
 			input:            "testdata/firewall_dmz_app_storage.yaml",
+			frrVersion:       semver.MustParse("8.5"),
 			expectedOutput:   "testdata/frr.conf.firewall_dmz_app_storage",
 			configuratorType: Firewall,
 			tpl:              TplFirewallFRR,
@@ -58,6 +63,7 @@ func TestFrrConfigApplier(t *testing.T) {
 		{
 			name:             "firewall with private primary unshared ipv6 network, private secondary shared ipv4 network, ipv6 internet and ipv4 mpls",
 			input:            "testdata/firewall_ipv6.yaml",
+			frrVersion:       semver.MustParse("8.5"),
 			expectedOutput:   "testdata/frr.conf.firewall_ipv6",
 			configuratorType: Firewall,
 			tpl:              TplFirewallFRR,
@@ -65,6 +71,7 @@ func TestFrrConfigApplier(t *testing.T) {
 		{
 			name:             "firewall with private primary unshared ipv6 network, private secondary shared ipv4 network, dualstack internet and ipv4 mpls",
 			input:            "testdata/firewall_dualstack.yaml",
+			frrVersion:       semver.MustParse("8.5"),
 			expectedOutput:   "testdata/frr.conf.firewall_dualstack",
 			configuratorType: Firewall,
 			tpl:              TplFirewallFRR,
@@ -72,6 +79,7 @@ func TestFrrConfigApplier(t *testing.T) {
 		{
 			name:             "standard machine",
 			input:            "testdata/machine.yaml",
+			frrVersion:       semver.MustParse("8.5"),
 			expectedOutput:   "testdata/frr.conf.machine",
 			configuratorType: Machine,
 			tpl:              TplMachineFRR,

--- a/pkg/netconf/testdata/frr.conf.firewall_frr-10
+++ b/pkg/netconf/testdata/frr.conf.firewall_frr-10
@@ -1,6 +1,6 @@
 # This file was auto generated for machine: 'e0ab02d2-27cd-5a5e-8efc-080ba80cf258' by app version .
 # Do not edit.
-frr version 8.5
+frr version 10.1
 frr defaults datacenter
 hostname firewall
 !
@@ -36,6 +36,7 @@ interface lan1
 !
 router bgp 4200003073
  bgp router-id 10.1.0.1
+ no bgp enforce-first-as
  bgp bestpath as-path multipath-relax
  neighbor FABRIC peer-group
  neighbor FABRIC remote-as external

--- a/pkg/netconf/testdata/frr.conf.firewall_frr-9
+++ b/pkg/netconf/testdata/frr.conf.firewall_frr-9
@@ -1,6 +1,6 @@
 # This file was auto generated for machine: 'e0ab02d2-27cd-5a5e-8efc-080ba80cf258' by app version .
 # Do not edit.
-frr version 8.5
+frr version 9.0
 frr defaults datacenter
 hostname firewall
 !

--- a/pkg/netconf/tpl/frr.firewall.tpl
+++ b/pkg/netconf/tpl/frr.firewall.tpl
@@ -2,7 +2,9 @@
 {{- $ASN := .ASN -}}
 {{- $RouterId := .RouterID -}}
 {{ .Comment }}
-frr version {{ .FRRVersion }}
+{{- if and (.FRRVersion) }}
+frr version {{ .FRRVersion.Major }}.{{ .FRRVersion.Minor }}
+{{- end }}
 frr defaults datacenter
 hostname {{ .Hostname }}
 !
@@ -28,6 +30,9 @@ interface lan1
 !
 router bgp {{ .ASN }}
  bgp router-id {{ .RouterID }}
+{{- if and (.FRRVersion) (gt .FRRVersion.Major 9) }}
+ no bgp enforce-first-as
+{{- end }}
  bgp bestpath as-path multipath-relax
  neighbor FABRIC peer-group
  neighbor FABRIC remote-as external

--- a/pkg/netconf/tpl/frr.machine.tpl
+++ b/pkg/netconf/tpl/frr.machine.tpl
@@ -2,7 +2,9 @@
 {{- $ASN := .ASN -}}
 {{- $RouterId := .RouterID -}}
 {{ .Comment }}
-frr version {{ .FRRVersion }}
+{{- if and (.FRRVersion) }}
+frr version {{ .FRRVersion.Major }}.{{ .FRRVersion.Minor }}
+{{- end }}
 frr defaults datacenter
 hostname {{ .Hostname }}
 allow-reserved-ranges


### PR DESCRIPTION
## Description

It turns out that adding `no bgp enforce-first-as` to the VRF BGP Instances is not enough to create a stable working firewall upon first start, it still requires a `frr reload` sometimes. We observed that after the reload, this entry was added to the underlay section as well. So do this always.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
