### PR TITLE
Ensure systemd-networkd-wait-online works properly

### DIFF
--- a/pkg/netconf/testdata/networkd/firewall/10-lan0.network
+++ b/pkg/netconf/testdata/networkd/firewall/10-lan0.network
@@ -4,6 +4,7 @@
 Name=lan0
 
 [Network]
+IPv6AcceptRA=no
 VXLAN=vni3981
 VXLAN=vni3982
 VXLAN=vni104009

--- a/pkg/netconf/testdata/networkd/firewall/11-lan1.network
+++ b/pkg/netconf/testdata/networkd/firewall/11-lan1.network
@@ -4,6 +4,7 @@
 Name=lan1
 
 [Network]
+IPv6AcceptRA=no
 VXLAN=vni3981
 VXLAN=vni3982
 VXLAN=vni104009

--- a/pkg/netconf/testdata/networkd/machine/10-lan0.network
+++ b/pkg/netconf/testdata/networkd/machine/10-lan0.network
@@ -4,3 +4,4 @@
 Name=lan0
 
 [Network]
+IPv6AcceptRA=no

--- a/pkg/netconf/testdata/networkd/machine/11-lan1.network
+++ b/pkg/netconf/testdata/networkd/machine/11-lan1.network
@@ -4,3 +4,4 @@
 Name=lan1
 
 [Network]
+IPv6AcceptRA=no

--- a/pkg/netconf/tpl/networkd/10-lan.network.tpl
+++ b/pkg/netconf/tpl/networkd/10-lan.network.tpl
@@ -4,6 +4,7 @@
 Name=lan{{ .Index }}
 
 [Network]
+IPv6AcceptRA=no
 {{- range .EVPNIfaces }}
 VXLAN=vni{{ .VXLAN.ID }}
 {{- end }}


### PR DESCRIPTION
## Description

To ensure the unnumbered interfaces enter the "configured" state, which is required for `systemd-networkd-wait-online` to work properly, all dynamic address configuration mechanisms like `DHCP=` and `IPv6AcceptRA=` need to be disabled. Otherwise, the interface will remain in the "configuring" state, and `systemd-networkd-wait-online` will timeout for the interface.

By default, IPv6AcceptRA is enabled and controls the userspace implementation of the IPv6 RA protocol in `systemd-netword`. This means there is so no interference with FRR.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
